### PR TITLE
Logs development

### DIFF
--- a/Assets/Scenes/ARGP_Home.unity
+++ b/Assets/Scenes/ARGP_Home.unity
@@ -123,11 +123,6 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1 &139027738 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1970900254558334, guid: 0a3b6392f04558844bd340e68ced1ff9, type: 3}
-  m_PrefabInstance: {fileID: 777839397}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &329207883
 GameObject:
   m_ObjectHideFlags: 0
@@ -264,7 +259,6 @@ GameObject:
   - component: {fileID: 680664930}
   - component: {fileID: 680664927}
   - component: {fileID: 680664929}
-  - component: {fileID: 680664928}
   - component: {fileID: 680664932}
   - component: {fileID: 680664933}
   - component: {fileID: 680664934}
@@ -319,18 +313,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   prefab_target: {fileID: 6191735313798834387, guid: eddd8aa18d65f4b42b025520487cefe3, type: 3}
   is_mirrored: 0
---- !u!114 &680664928
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 680664924}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9d07ef1844325b440bb4789ee0c0534f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &680664929
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -425,6 +407,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   file_path: D:\data_storage\argp_data\unity_testing
+  fileSaver: {fileID: 1031618742}
 --- !u!1 &705507993
 GameObject:
   m_ObjectHideFlags: 0
@@ -786,6 +769,10 @@ PrefabInstance:
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6301449615104170796, guid: 0a3b6392f04558844bd340e68ced1ff9, type: 3}
+      propertyPath: dataSaveLocation
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 7587908648779123904, guid: 0a3b6392f04558844bd340e68ced1ff9, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -857,28 +844,23 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 114916036141644208, guid: 0a3b6392f04558844bd340e68ced1ff9, type: 3}
   m_PrefabInstance: {fileID: 777839397}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 139027738}
+  m_GameObject: {fileID: 0}
   m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fa9f2505d11cc9e4aa44357b47b12905, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &777839401
+--- !u!114 &1031618742 stripped
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 6301449615104170796, guid: 0a3b6392f04558844bd340e68ced1ff9, type: 3}
+  m_PrefabInstance: {fileID: 777839397}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 139027738}
+  m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 687ae971276a0ce43b007cabf739be5b, type: 3}
+  m_Script: {fileID: 11500000, guid: c998d809839214b438495bbe6d805bd0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  prefab_Start_Bar: {fileID: 0}
-  prefab_End_Bar: {fileID: 0}
-  left_bar_location_xyz: {x: 0, y: 0, z: 0}
-  right_bar_location_xyz: {x: 0, y: 0, z: 0}
 --- !u!1 &1272964765
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/ARGP_Home.unity
+++ b/Assets/Scenes/ARGP_Home.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 705507994}
-  m_IndirectSpecularColor: {r: 0.4366756, g: 0.48427194, b: 0.5645252, a: 1}
+  m_IndirectSpecularColor: {r: 0.4366757, g: 0.48427194, b: 0.5645252, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -268,6 +268,7 @@ GameObject:
   - component: {fileID: 680664932}
   - component: {fileID: 680664933}
   - component: {fileID: 680664934}
+  - component: {fileID: 680664935}
   m_Layer: 0
   m_Name: ScriptHolder
   m_TagString: Untagged
@@ -411,6 +412,19 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6eb9704473362ce4b8ace8e4587cf919, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &680664935
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 680664924}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8ca8491b7e09ba34da457f9493c1ab8d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  file_path: D:\data_storage\argp_data\unity_testing
 --- !u!1 &705507993
 GameObject:
   m_ObjectHideFlags: 0
@@ -1151,7 +1165,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!65 &1803798471
 BoxCollider:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/LoadTerrain.cs
+++ b/Assets/Scripts/LoadTerrain.cs
@@ -14,7 +14,7 @@ public class LoadTerrain : MonoBehaviour
     private string file_name;
     private TextAsset terrain_file;
 
-    private UXF.UXFDataTable terrain_objects_data_table;
+    private Dictionary<int,Vector3> terrain_objects_dict;
 
     private UXFDataRow new_row;
 
@@ -57,7 +57,7 @@ public class LoadTerrain : MonoBehaviour
         
         // create a dictonary to fill with all terrain objects
 
-        // terrain_objects_data_table = new UXFDataTable(1,"test");
+        terrain_objects_dict = new Dictionary<int, Vector3>();
 
         for (int i = 1; i < terrain_info.Length -1; i++)
         {   
@@ -86,10 +86,16 @@ public class LoadTerrain : MonoBehaviour
 
             Debug.Log("Tar Loc:" + target.transform.position.ToString("F4"));
 
-            // new_row = new UXFDataRow[1, target.transform.position.ToString("F4")];
-
-            // terrain_objects_data_table.AddCompleteRow(new_row);
+            terrain_objects_dict.Add(i,target.transform.position);
 
         }
+
+        Debug.Log("Terrain Dictionary: "+ terrain_objects_dict);
+
+        foreach(var item in terrain_objects_dict)
+        {
+            Debug.Log("Dictionary items:" + item);
+        }
+
     }
 }

--- a/Assets/Scripts/LoadTerrain.cs
+++ b/Assets/Scripts/LoadTerrain.cs
@@ -16,7 +16,9 @@ public class LoadTerrain : MonoBehaviour
 
     private Dictionary<int,Vector3> terrain_objects_dict;
 
-    private UXFDataRow new_row;
+    private string terrain_dict_file_name;
+
+
 
     public void GenerateTerrain(Trial trial)
     {
@@ -96,6 +98,10 @@ public class LoadTerrain : MonoBehaviour
         {
             Debug.Log("Dictionary items:" + item);
         }
+
+        terrain_dict_file_name = String.Format("terrain_dict-trialnum-" + trial.number + "-filename-" + file_name);
+
+        Trial.SaveJSONSerializableObject(terrain_objects_dict, terrain_dict_file_name);
 
     }
 }

--- a/Assets/Scripts/LoadTerrain.cs
+++ b/Assets/Scripts/LoadTerrain.cs
@@ -99,7 +99,5 @@ public class LoadTerrain : MonoBehaviour
 
         writeCSV.WriteTerrainObjectsOnTrialStart(terrain_dict_file_name, terrain_objects_dict);
 
-        // consider writing and saving a `.csv` file instead of a dictionary
-
     }
 }

--- a/Assets/Scripts/LoadTerrain.cs
+++ b/Assets/Scripts/LoadTerrain.cs
@@ -10,19 +10,22 @@ public class LoadTerrain : MonoBehaviour
 
     //public Session session;
     public GameObject prefab_target;
+
     public bool is_mirrored;
+
     private string file_name;
+
     private TextAsset terrain_file;
 
-    private Dictionary<int,Vector3> terrain_objects_dict;
+    private Dictionary<int,string> terrain_objects_dict;
 
     private string terrain_dict_file_name;
 
-
+    WriteCSV writeCSV;
 
     public void GenerateTerrain(Trial trial)
     {
-
+        
         Debug.Log("Terrain is Loaded");
         Debug.Log("is_mirrored:" + is_mirrored);
         // get the positions of each of the projectors
@@ -48,8 +51,6 @@ public class LoadTerrain : MonoBehaviour
 
         TextAsset terrain_file = Resources.Load<TextAsset>(file_name); // feed in the file name without `.csv` appended to it
 
-        // Debug.Log("Terrain File Type:: " + terrain_file); // this doesn't seem to be doing us any favors at the moment; it prints out a garbled mess Probably should delete.
-
         // split up the data by line
         string[] terrain_info = terrain_file.text.Split(new char[] { '\n' });
 
@@ -59,7 +60,7 @@ public class LoadTerrain : MonoBehaviour
         
         // create a dictonary to fill with all terrain objects
 
-        terrain_objects_dict = new Dictionary<int, Vector3>();
+        terrain_objects_dict = new Dictionary<int, string>();
 
         for (int i = 1; i < terrain_info.Length -1; i++)
         {   
@@ -88,20 +89,16 @@ public class LoadTerrain : MonoBehaviour
 
             Debug.Log("Tar Loc:" + target.transform.position.ToString("F4"));
 
-            terrain_objects_dict.Add(i,target.transform.position);
+            terrain_objects_dict.Add(i,target.transform.position.ToString("F4"));
 
         }
 
-        Debug.Log("Terrain Dictionary: "+ terrain_objects_dict);
+        writeCSV=GameObject.Find("ScriptHolder").GetComponent<WriteCSV>();
 
-        foreach(var item in terrain_objects_dict)
-        {
-            Debug.Log("Dictionary items:" + item);
-        }
+        terrain_dict_file_name = String.Format("terrain_data-trialnum-" + trial.number + "-filename-" + file_name);
 
-        terrain_dict_file_name = String.Format("terrain_dict-trialnum-" + trial.number + "-filename-" + file_name);
+        writeCSV.WriteTerrainObjectsOnTrialStart(terrain_dict_file_name, terrain_objects_dict);
 
-        // https://github.com/azixMcAze/Unity-SerializableDictionary <- need this
         // consider writing and saving a `.csv` file instead of a dictionary
 
     }

--- a/Assets/Scripts/LoadTerrain.cs
+++ b/Assets/Scripts/LoadTerrain.cs
@@ -14,6 +14,10 @@ public class LoadTerrain : MonoBehaviour
     private string file_name;
     private TextAsset terrain_file;
 
+    private UXF.UXFDataTable terrain_objects_data_table;
+
+    private UXFDataRow new_row;
+
     public void GenerateTerrain(Trial trial)
     {
 
@@ -38,9 +42,11 @@ public class LoadTerrain : MonoBehaviour
         
         Debug.Log("Name of Trial File: " + file_name);
 
+        Debug.Log("trialnum-" + trial.number + "-filename-" + file_name); // this will be the name of the file we're saving
+
         TextAsset terrain_file = Resources.Load<TextAsset>(file_name); // feed in the file name without `.csv` appended to it
 
-        Debug.Log("Terrain File Type:: " + terrain_file);
+        // Debug.Log("Terrain File Type:: " + terrain_file); // this doesn't seem to be doing us any favors at the moment; it prints out a garbled mess Probably should delete.
 
         // split up the data by line
         string[] terrain_info = terrain_file.text.Split(new char[] { '\n' });
@@ -48,7 +54,11 @@ public class LoadTerrain : MonoBehaviour
         // Loop through the length of the list and create game objects
         // subtract 1 from length because Unity reads in an empty line at the end
         // start at i = 1 because we're giving our csv a header
-        //Debug.Log(terrain_info.Length);
+        
+        // create a dictonary to fill with all terrain objects
+
+        // terrain_objects_data_table = new UXFDataTable(1,"test");
+
         for (int i = 1; i < terrain_info.Length -1; i++)
         {   
             // Split up terrain by commas to give us each column
@@ -75,6 +85,11 @@ public class LoadTerrain : MonoBehaviour
             }
 
             Debug.Log("Tar Loc:" + target.transform.position.ToString("F4"));
+
+            // new_row = new UXFDataRow[1, target.transform.position.ToString("F4")];
+
+            // terrain_objects_data_table.AddCompleteRow(new_row);
+
         }
     }
 }

--- a/Assets/Scripts/LoadTerrain.cs
+++ b/Assets/Scripts/LoadTerrain.cs
@@ -95,7 +95,7 @@ public class LoadTerrain : MonoBehaviour
 
         writeCSV=GameObject.Find("ScriptHolder").GetComponent<WriteCSV>();
 
-        terrain_dict_file_name = String.Format("terrain_data-trialnum-" + trial.number + "-filename-" + file_name);
+        terrain_dict_file_name = String.Format("target_data-trialnum-" + trial.number + "-filename-" + file_name);
 
         writeCSV.WriteTerrainObjectsOnTrialStart(terrain_dict_file_name, terrain_objects_dict);
 

--- a/Assets/Scripts/LoadTerrain.cs
+++ b/Assets/Scripts/LoadTerrain.cs
@@ -101,7 +101,8 @@ public class LoadTerrain : MonoBehaviour
 
         terrain_dict_file_name = String.Format("terrain_dict-trialnum-" + trial.number + "-filename-" + file_name);
 
-        Trial.SaveJSONSerializableObject(terrain_objects_dict, terrain_dict_file_name);
+        // https://github.com/azixMcAze/Unity-SerializableDictionary <- need this
+        // consider writing and saving a `.csv` file instead of a dictionary
 
     }
 }

--- a/Assets/Scripts/TriggerSoundTarget.cs
+++ b/Assets/Scripts/TriggerSoundTarget.cs
@@ -40,7 +40,9 @@ public class TriggerSoundTarget : MonoBehaviour
                 // play the collect sound (at the same position as the target, 100% volume)
                 AudioSource.PlayClipAtPoint(soundTrigger, transform.position, 1.0f);
                 sound_has_played = true;
-                Debug.Log("Triggered Tar:" + colliding_object.transform.position.ToString("F4"));
+                System.DateTime epochStart = new System.DateTime(1970, 1, 1, 0, 0, 0, System.DateTimeKind.Utc);
+                int cur_time = (int)(System.DateTime.UtcNow - epochStart).TotalSeconds;
+                Debug.Log("Triggered Tar:" + colliding_object.transform.position.ToString("F4") + " at Epoch Time " + cur_time.ToString());
             }
         }
         

--- a/Assets/Scripts/WriteCSV.cs
+++ b/Assets/Scripts/WriteCSV.cs
@@ -28,7 +28,7 @@ public class WriteCSV : MonoBehaviour
 
             // for later: if there are no targets collided with, save an empty file
 
-            // save start end box positions - can I save the start/end boxes as text files?    
+            // save start end box positions - can I save the start/end boxes as text files? -> don't lose time over this though
 
             using (System.IO.StreamWriter file = new System.IO.StreamWriter(@file_path_with_file_name, true)) 
             {

--- a/Assets/Scripts/WriteCSV.cs
+++ b/Assets/Scripts/WriteCSV.cs
@@ -3,27 +3,31 @@ using System.Collections.Generic;
 using System;
 using System.IO;
 using UnityEngine;
-
+using UXF;
 
 public class WriteCSV : MonoBehaviour
 {
-    public String file_path;
+    
+    // private String object_position_string;
 
-    private String file_path_with_file_name;
-
-    private String object_position_string;
+    public FileSaver fileSaver;
 
     public void WriteTerrainObjectsOnTrialStart(String terrain_dict_file_name, Dictionary<int,string> terrain_objects_dict)
     {
        
-        file_path_with_file_name = String.Format(file_path + "\\" + terrain_dict_file_name + ".csv");
+        string sessionPath = fileSaver.GetSessionPath(Session.instance);
+
+        string sessionPathWithTerrainFolder = String.Format(sessionPath + "\\" + "ar_terrain_data");
+
+        // Create the folder so we can save the data -> this doesn't seem to break any other UXF processes
+        var folder = Directory.CreateDirectory(sessionPathWithTerrainFolder); 
+
+        string file_path_with_file_name = String.Format(sessionPathWithTerrainFolder + "\\" + terrain_dict_file_name + ".csv");
+
+        System.DateTime epochStart = new System.DateTime(1970, 1, 1, 0, 0, 0, System.DateTimeKind.Utc);
 
         try
         {
-            // Build the file path based off of the UXF folder     
-
-            // translate what I'm saving into qualisys coordinates
-
             // for later: if there are no targets collided with, save an empty file
 
             // save start end box positions - can I save the start/end boxes as text files? -> don't lose time over this though
@@ -32,24 +36,27 @@ public class WriteCSV : MonoBehaviour
 
             using (System.IO.StreamWriter file = new System.IO.StreamWriter(@file_path_with_file_name, true)) 
             {
-                Debug.LogWarning("Files are about to be saved, make sure that you're working in a clean & new folder!!!");
 
-                file.WriteLine("X, Y, Z");
+                file.WriteLine("epoch_time_stamp, X, Y, Z");
 
                 foreach(var item in terrain_objects_dict)
                 {
                     // Find out how long the string is and then keep the substring between the "(" ")"
 
-                    object_position_string = item.Value;
+                    string object_position_string = item.Value;
 
                     int string_length = object_position_string.Length - 2;
 
                     object_position_string = object_position_string.Substring(1, string_length);
 
-                    file.WriteLine(object_position_string);
+                    int cur_time = (int)(System.DateTime.UtcNow - epochStart).TotalSeconds;
+
+                    string string_to_write = String.Format(cur_time.ToString() + ',' + object_position_string);
+
+                    file.WriteLine(string_to_write);
                 }
 
-                Debug.Log("Inside of WriteCSV! Files being saved here : " + file_path);
+                Debug.Log("Inside of WriteCSV! Files being saved here : " + sessionPathWithTerrainFolder);
             }   
         }   
         catch(Exception ex)

--- a/Assets/Scripts/WriteCSV.cs
+++ b/Assets/Scripts/WriteCSV.cs
@@ -20,8 +20,17 @@ public class WriteCSV : MonoBehaviour
 
         try
         {
-                        
-            using (System.IO.StreamWriter file = new System.IO.StreamWriter(@file_path_with_file_name, true))
+            // Build the file path based off of the UXF folder
+
+            // add the position of the projector to the position of the target        
+
+            // translate what I'm saving into qualisys coordinates
+
+            // for later: if there are no targets collided with, save an empty file
+
+            // save start end box positions - can I save the start/end boxes as text files?    
+
+            using (System.IO.StreamWriter file = new System.IO.StreamWriter(@file_path_with_file_name, true)) 
             {
                 Debug.LogWarning("Files are about to be saved, make sure that you're working in a clean & new folder!!!");
 
@@ -45,7 +54,7 @@ public class WriteCSV : MonoBehaviour
         }   
         catch(Exception ex)
         {
-            throw new ApplicationException("Write CSV is broken!:", ex);
+            throw new ApplicationException("WriteCSV is broken!:", ex);
         }
 
     }

--- a/Assets/Scripts/WriteCSV.cs
+++ b/Assets/Scripts/WriteCSV.cs
@@ -28,6 +28,8 @@ public class WriteCSV : MonoBehaviour
 
             // save start end box positions - can I save the start/end boxes as text files? -> don't lose time over this though
 
+            // save intelligent timestamp data
+
             using (System.IO.StreamWriter file = new System.IO.StreamWriter(@file_path_with_file_name, true)) 
             {
                 Debug.LogWarning("Files are about to be saved, make sure that you're working in a clean & new folder!!!");

--- a/Assets/Scripts/WriteCSV.cs
+++ b/Assets/Scripts/WriteCSV.cs
@@ -8,8 +8,6 @@ using UXF;
 public class WriteCSV : MonoBehaviour
 {
     
-    // private String object_position_string;
-
     public FileSaver fileSaver;
 
     public void WriteTerrainObjectsOnTrialStart(String terrain_dict_file_name, Dictionary<int,string> terrain_objects_dict)

--- a/Assets/Scripts/WriteCSV.cs
+++ b/Assets/Scripts/WriteCSV.cs
@@ -20,9 +20,7 @@ public class WriteCSV : MonoBehaviour
 
         try
         {
-            // Build the file path based off of the UXF folder
-
-            // add the position of the projector to the position of the target        
+            // Build the file path based off of the UXF folder     
 
             // translate what I'm saving into qualisys coordinates
 

--- a/Assets/Scripts/WriteCSV.cs
+++ b/Assets/Scripts/WriteCSV.cs
@@ -1,0 +1,53 @@
+using System.Collections;
+using System.Collections.Generic;
+using System;
+using System.IO;
+using UnityEngine;
+
+
+public class WriteCSV : MonoBehaviour
+{
+    public String file_path;
+
+    private String file_path_with_file_name;
+
+    private String object_position_string;
+
+    public void WriteTerrainObjectsOnTrialStart(String terrain_dict_file_name, Dictionary<int,string> terrain_objects_dict)
+    {
+       
+        file_path_with_file_name = String.Format(file_path + "\\" + terrain_dict_file_name + ".csv");
+
+        try
+        {
+                        
+            using (System.IO.StreamWriter file = new System.IO.StreamWriter(@file_path_with_file_name, true))
+            {
+                Debug.LogWarning("Files are about to be saved, make sure that you're working in a clean & new folder!!!");
+
+                file.WriteLine("X, Y, Z");
+
+                foreach(var item in terrain_objects_dict)
+                {
+                    // Find out how long the string is and then keep the substring between the "(" ")"
+
+                    object_position_string = item.Value;
+
+                    int string_length = object_position_string.Length - 2;
+
+                    object_position_string = object_position_string.Substring(1, string_length);
+
+                    file.WriteLine(object_position_string);
+                }
+
+                Debug.Log("Inside of WriteCSV! Files being saved here : " + file_path);
+            }   
+        }   
+        catch(Exception ex)
+        {
+            throw new ApplicationException("Write CSV is broken!:", ex);
+        }
+
+    }
+
+}

--- a/Assets/Scripts/WriteCSV.cs.meta
+++ b/Assets/Scripts/WriteCSV.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8ca8491b7e09ba34da457f9493c1ab8d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # AR_GroundPlane
 HuMoN repo for the Augmented Reality Ground Plane (2022-07-28)
+
+Using Unity Version: 2021.3.6f1


### PR DESCRIPTION
currently, every trial's targets are being saved out in its own file - following the UXF file path

all target collisions are printed to the console with the epoch time stamp of the collision. I will pull out target collisions from the console logs... 